### PR TITLE
Don't really need indicatif

### DIFF
--- a/Sources/src-rusty-improved/Cargo.toml
+++ b/Sources/src-rusty-improved/Cargo.toml
@@ -7,7 +7,6 @@ edition = "2021"
 anyhow = "1.0.65"
 colored = "2.0.0"
 fs_extra = "1.2.0"
-indicatif = "0.17.1"
 serde_json = "1.0.85"
 serde = { version = "1.0.145", features = ["derive"] }
 


### PR DESCRIPTION
I had indicatif in the Cargo.toml because I previously planned to make a progress bar, but then realised the program is fast enough to the point where it was practically useless. This decreases the binary size... just remembered this! sorry!